### PR TITLE
Alterations to make jerrycan quality update

### DIFF
--- a/source/fuel_client.lua
+++ b/source/fuel_client.lua
@@ -249,7 +249,7 @@ Citizen.CreateThread(function()
 									if #items > 0 then
 										local can = items[1]
 					
-										local refillCost = Round(Config.RefillCost * (1 - can.info.ammo / 4500))
+										local refillCost = Round(Config.RefillCost * (1 - can.info.quality / 4500))
 										if refillCost > 0 then
 											if currentCash >= refillCost then			
 												TriggerServerEvent('fuel:pay', refillCost, GetPlayerServerId(PlayerId()))

--- a/source/fuel_client.lua
+++ b/source/fuel_client.lua
@@ -244,10 +244,7 @@ Citizen.CreateThread(function()
 					if currentCash >= Config.JerryCanCost then
 						DrawText3Ds(stringCoords.x, stringCoords.y, stringCoords.z + 1.2, Config.Strings.PurchaseJerryCan)
 						if IsControlJustReleased(0, 38) then
-							print("INPUT")
 							QBCore.Functions.TriggerCallback('fuel:server:hasJerryCans', function(hasCans, items)  
-								print(hasCans)
-								print(items)	
 								if hasCans then
 									if #items > 0 then
 										local can = items[1]

--- a/source/fuel_client.lua
+++ b/source/fuel_client.lua
@@ -37,7 +37,7 @@ function GetJerryCanState()
     end
 end
 
-AddEventHandler("LefacyFuel:SetJerryCan", function (data)
+AddEventHandler("fuel:SetJerryCan", function (data)
 	jerryCan = data
 end)
 

--- a/source/fuel_server.lua
+++ b/source/fuel_server.lua
@@ -7,3 +7,35 @@ AddEventHandler('fuel:pay', function(price, source)
 		xPlayer.Functions.RemoveMoney('cash', amount)
 	end
 end)
+
+QBCore.Functions.CreateCallback('fuel:server:hasJerryCans', function(source, cb)
+    local Player = QBCore.Functions.GetPlayer(source)
+    local cans = Player.Functions.GetItemsByName("weapon_petrolcan")
+    local retVal = false
+	local nonFull = {}
+
+    if #cans > 0 then
+        for k, v in pairs(cans) do
+			if v.info ~= nil then
+				if v.info.quality ~= nil and v.info.quality < 100 then
+					table.insert(nonFull, v)
+					retVal = true
+				end
+			end
+		end
+    end
+
+    cb(retVal, nonFull)
+end)
+
+RegisterServerEvent('fuel:server:swapJerryCan')
+AddEventHandler("fuel:server:swapJerryCan", function (slot)
+    local Player = QBCore.Functions.GetPlayer(source)
+    
+    Player.Functions.RemoveItem("weapon_petrolcan", 1, slot)
+    TriggerClientEvent("inventory:client:ItemBox", source, QBCore.Shared.Items["weapon_petrolcan"], "remove")
+    Player.Functions.AddItem("weapon_petrolcan", 1, slot, {
+        ["quality"] = 100
+    })
+    TriggerClientEvent("inventory:client:ItemBox", source, QBCore.Shared.Items["weapon_petrolcan"], "add")
+end)


### PR DESCRIPTION
This allows the jerry can items quality to update when it is used to refuel a vehicle.
Requires changes to qb-weapons and qb-inventory

https://github.com/qbcore-framework/qb-weapons/pull/33
https://github.com/qbcore-framework/qb-inventory/pull/90