### PR TITLE
Updated GetFuel

### DIFF
--- a/functions/functions_client.lua
+++ b/functions/functions_client.lua
@@ -1,4 +1,7 @@
 function GetFuel(vehicle)
+	if not DecorExistOn(vehicle, Config.FuelDecor) then
+		SetInitialFuelLevel(vehicle)
+	end
 	return DecorGetFloat(vehicle, Config.FuelDecor)
 end
 
@@ -7,6 +10,10 @@ function SetFuel(vehicle, fuel)
 		SetVehicleFuelLevel(vehicle, fuel + 0.0)
 		DecorSetFloat(vehicle, Config.FuelDecor, GetVehicleFuelLevel(vehicle))
 	end
+end
+
+function SetInitialFuelLevel(vehicle)
+	SetFuel(vehicle, math.random(200, 800) / 10)
 end
 
 function LoadAnimDict(dict)
@@ -56,6 +63,7 @@ function CreateBlip(coords)
 	return blip
 end
 
+-- GetEntityModel(object) will error out if the entity exists, but isnt loaded yet.
 function FindNearestFuelPump()
 	local coords = GetEntityCoords(PlayerPedId())
 	local fuelPumps = {}

--- a/functions/functions_client.lua
+++ b/functions/functions_client.lua
@@ -1,5 +1,5 @@
 function GetFuel(vehicle)
-	if not DoesEntityExist(vehicle) then end
+	if not DoesEntityExist(vehicle) then return end
 
 	if not DecorExistOn(vehicle, Config.FuelDecor) then
 		SetInitialFuelLevel(vehicle)
@@ -8,7 +8,7 @@ function GetFuel(vehicle)
 end
 
 function SetFuel(vehicle, fuel)
-	if not DoesEntityExist(vehicle) then end
+	if not DoesEntityExist(vehicle) then return end
 	
 	if type(fuel) == 'number' and fuel >= 0 and fuel <= 100 then
 		SetVehicleFuelLevel(vehicle, fuel + 0.0)

--- a/functions/functions_client.lua
+++ b/functions/functions_client.lua
@@ -1,4 +1,6 @@
 function GetFuel(vehicle)
+	if not DoesEntityExist(vehicle) then end
+
 	if not DecorExistOn(vehicle, Config.FuelDecor) then
 		SetInitialFuelLevel(vehicle)
 	end
@@ -6,6 +8,8 @@ function GetFuel(vehicle)
 end
 
 function SetFuel(vehicle, fuel)
+	if not DoesEntityExist(vehicle) then end
+	
 	if type(fuel) == 'number' and fuel >= 0 and fuel <= 100 then
 		SetVehicleFuelLevel(vehicle, fuel + 0.0)
 		DecorSetFloat(vehicle, Config.FuelDecor, GetVehicleFuelLevel(vehicle))

--- a/source/fuel_client.lua
+++ b/source/fuel_client.lua
@@ -10,7 +10,7 @@ local inBlacklisted = false
 
 function ManageFuelUsage(vehicle)
 	if not DecorExistOn(vehicle, Config.FuelDecor) then
-		SetFuel(vehicle, math.random(200, 800) / 10)
+		SetInitialFuelLevel(vehicle)
 	elseif not fuelSynced then
 		SetFuel(vehicle, GetFuel(vehicle))
 


### PR DESCRIPTION
If GetFuel gets called and no Decorator has been set for the vehicle, we set one for it.

This stops vehicles generated vehicles that havn't been entered yet from returning 0.0 as their fuel.